### PR TITLE
Fixed typo in 31-multi-files.md

### DIFF
--- a/_episodes/31-multi-files.md
+++ b/_episodes/31-multi-files.md
@@ -199,8 +199,8 @@ for filename in sys.argv[1:]:
     ax.set_xticklabels(data.index, rotation = 45)
 
     # save the plot with a unique file name
-    split_name1 = file.split('.')[0] #data/gapminder_gdp_XXX
-    split_name2 = file.split('/')[1]
+    split_name1 = filename.split('.')[0] #data/gapminder_gdp_XXX
+    split_name2 = filename.split('/')[1]
     save_name = 'figs/'+split_name2 + '.png'
     plt.savefig(save_name)
 </pre>


### PR DESCRIPTION
Fix typo: 'file' should be 'filename'