### PR TITLE
Fix some typos in 31-multi-files.md

### DIFF
--- a/_episodes/31-multi-files.md
+++ b/_episodes/31-multi-files.md
@@ -199,8 +199,8 @@ for filename in sys.argv[1:]:
     ax.set_xticklabels(data.index, rotation = 45)
 
     # save the plot with a unique file name
-    split_name1 = file.split('.')[0] #data/gapminder_gdp_XXX
-    split_name2 = file.split('/')[1]
+    split_name1 = filename.split('.')[0] #data/gapminder_gdp_XXX
+    split_name2 = split_name1.split('/')[1]
     save_name = 'figs/'+split_name2 + '.png'
     plt.savefig(save_name)
 </pre>
@@ -320,7 +320,7 @@ ax.set_xticklabels(data.index, rotation = 45)
 
 <b># save the plot with a unique file name
 split_name1 = filename.split('.')[0] #data/gapminder_gdp_XXX
-split_name2 = filename.split('/')[1]
+split_name2 = split_name1.split('/')[1]
 save_name = 'figs/'+split_name2 + '.png'
 plt.savefig(save_name)</b>
 </pre>
@@ -378,7 +378,7 @@ Let's checkout our python branch and time our script there.
 
 ~~~
 $ git checkout python-multi-files
-$ time python gdp_plots.py gapminder_gdp_oceania.csv gapminder_gdp_africa.csv
+$ time python gdp_plots.py data/gapminder_gdp_oceania.csv data/gapminder_gdp_africa.csv
 ~~~
 {: .bash}
 


### PR DESCRIPTION
split_name1 = filename.split('.')[0] #data/gapminder_gdp_XXX
split_name2 = split_name1.split('/')[1]

Fix some typos in 31-multi-files.md
- file should be filename
- replace file with split_name1 when appropriate
- add 'data/' before referencing data files as fxn inputs